### PR TITLE
[fix(s3)]: Use urlparse instead of normal str split

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -33,4 +33,6 @@ jobs:
       - name: Install projects dependencies
         run: poetry install
       - name: Linters & Formatters
-        run: poetry run format
+        run: poetry run check
+      - name: Tests
+        run: ENV_FOR_DYNACONF=testing poetry run pytest

--- a/mini_sedric/s3_integration/clients.py
+++ b/mini_sedric/s3_integration/clients.py
@@ -1,4 +1,5 @@
 """Module for implementations of S3Interface ABC class"""
+from urllib.parse import urlparse
 
 import boto3
 import botocore
@@ -35,8 +36,11 @@ class S3AWSInterface(S3Interface):
 
     def check(self, uri: str) -> bool:
         try:
-            sanitized_uri = uri.lstrip("s3://").rsplit("/")
-            self.s3_client.head_object(Bucket=sanitized_uri[0], Key=sanitized_uri[1])
+            parsed_s3_uri = urlparse(uri)
+            self.s3_client.head_object(
+                Bucket=parsed_s3_uri.netloc,
+                Key=parsed_s3_uri.path.lstrip("/"),
+            )
         except botocore.exceptions.ClientError as e:
             if e.response["Error"]["Code"] == "404":
                 print("Object not found!")

--- a/mini_sedric/s3_integration/clients.py
+++ b/mini_sedric/s3_integration/clients.py
@@ -1,4 +1,5 @@
 """Module for implementations of S3Interface ABC class"""
+
 from urllib.parse import urlparse
 
 import boto3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ boto3-stubs = "^1.34.127"
 
 [tool.poetry.scripts]
 format = "scripts.scripts:format"
+check = "scripts.scripts:check"
 
 [tool.isort]
 profile = "black"

--- a/scripts/scripts.py
+++ b/scripts/scripts.py
@@ -9,6 +9,26 @@ def format():
         [
             "autoflake",
             "-r",
+            "--cd",
+            "--remove-all-unused-imports",
+            "--ignore-init-module-imports",
+            "mini_sedric",
+            "tests",
+        ]
+    )
+    subprocess.run(["pylint", "mini_sedric/", "tests/"])
+    subprocess.run(["mypy", "mini_sedric/", "tests/"])
+
+
+def check():
+    subprocess.run(["black", "--check", "."])
+    subprocess.run(["isort", "--check", "."])
+    subprocess.run(["flake8", "mini_sedric/", "tests/"])
+    subprocess.run(
+        [
+            "autoflake",
+            "-r",
+            "-c",
             "--remove-all-unused-imports",
             "--ignore-init-module-imports",
             "mini_sedric",


### PR DESCRIPTION
Strip with "s3://" would remove all occurences of those characters ending in some problems with naming buckets